### PR TITLE
CI/CD - Prevent workflows from running on draft PRs

### DIFF
--- a/.github/workflows/core_integration_tests.yml
+++ b/.github/workflows/core_integration_tests.yml
@@ -3,7 +3,7 @@ name: Pycroglia Core package integration tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, reopened, ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/core_unit_test.yml
+++ b/.github/workflows/core_unit_test.yml
@@ -3,7 +3,7 @@ name: Pycroglia Core package unit tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, reopened, ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/python_linter_check.yml
+++ b/.github/workflows/python_linter_check.yml
@@ -3,7 +3,7 @@ name: Ruff linter check
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, reopened, ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/ui_unit_test.yml
+++ b/.github/workflows/ui_unit_test.yml
@@ -3,7 +3,7 @@ name: Pycroglia UI package unit tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, reopened, ready_for_review]
 
 jobs:
   build:


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
|https://github.com/CGK-Laboratory/pycroglia/issues/28 |

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
-->

This PR optimizes our CI/CD pipeline by preventing GitHub Actions workflows from running on draft PRs. Previously, all workflows were triggered when draft PRs were opened, leading to unnecessary resource consumption and workflow noise for incomplete work that is not ready for review.

## Proposed Changes

### **CI/CD Optimization**
- Modified all GitHub Actions workflow trigger configurations to exclude `opened` event type
- Workflows now only run when PRs are converted from draft to ready for review (`ready_for_review`)
- Maintained triggers for commits to existing ready-for-review PRs (`synchronize`) and reopened PRs (`reopened`)
- Preserved manual workflow execution capability (`workflow_dispatch`)

### **Files Modified**
- `.github/workflows/core_integration_tests.yml` - Updated PR trigger types
- `.github/workflows/core_unit_test.yml` - Updated PR trigger types  
- `.github/workflows/python_linter_check.yml` - Updated PR trigger types
- `.github/workflows/ui_unit_test.yml` - Updated PR trigger types
