### PR TITLE
Increase small objects filter max threshold to 5,000

### DIFF
--- a/pycroglia/ui/widgets/ch_img.py
+++ b/pycroglia/ui/widgets/ch_img.py
@@ -252,7 +252,7 @@ class SmallObjectsFilterEditor(QtWidgets.QWidget):
     """
 
     FILTER_MIN_VALUE = 1
-    FILTER_MAX_VALUE = 1000
+    FILTER_MAX_VALUE = 5000
 
     def __init__(
         self, state: MultiChImgEditorState, parent: Optional[QtWidgets.QWidget] = None


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
|https://github.com/CGK-Laboratory/pycroglia/issues/29 |

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
-->

This PR increases the maximum threshold value for the small objects filter from 5,000 to 10,000 pixels. The current limit was too restrictive for filtering larger objects in high-resolution images, limiting the flexibility of the segmentation workflow.

## Proposed Changes

### **UI Enhancement**
- Increased `FILTER_MAX_VALUE` constant from 1,000 to 5,000 in `SmallObjectsFilterEditor` class
- Updated the maximum range of the threshold spin box in the small objects filter UI
- Maintains backward compatibility with existing filter configurations

### **Files Modified**
- `pycroglia/ui/widgets/ch_img.py` - Updated `FILTER_MAX_VALUE` constant in `SmallObjectsFilterEditor`