### PR TITLE
Add average distance between centroids computation

### DIFF
--- a/pycroglia/core/centroid.py
+++ b/pycroglia/core/centroid.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+import numpy as np
+from  numpy.typing  import NDArray
+from scipy.spatial.distance import pdist, squareform
+
+
+class Centroids:
+    """Computes centroids of 3D cell masks and their average pairwise distance.
+
+    This class takes a list of 3D binary masks, extracts the centroid of each
+    non-empty mask, and provides a method to compute the average pairwise
+    distance between all centroids in physical units.
+
+    Attributes:
+        centroids (NDArray[np.float64]): Array of centroids with shape (N, 3),
+            where each row is (z, y, x) in voxel coordinates.
+    """
+    def __init__(self, masks: list[NDArray]) -> None:
+        """Initializes the Centroids object from binary masks.
+
+        Args:
+            masks (list[NDArray]): List of 3D binary masks (boolean or 0/1 arrays).
+                Each mask represents a segmented cell. The shape is (Z, Y, X).
+        """
+        centroids = []
+        for mask in masks:
+            coords = np.argwhere(mask) # voxel coords as (z,y,x)
+            if coords.size == 0:
+                continue
+            centroid = coords.mean(axis=0)
+            centroids.append(centroid)
+        self.centroids = np.array(centroids, dtype=np.float64)
+
+    def compute_average_distance(self, scale: float, zscale: float) -> float:
+        """Computes the average pairwise centroid distance in physical units.
+
+        Args:
+            scale (float): Scaling factor for X and Y dimensions (microns per pixel).
+            zscale (float): Scaling factor for Z dimension (microns per slice).
+
+        Returns:
+            float: The average Euclidean distance between centroids in microns.
+        """
+        self.centroids[:, 1] *= scale   # y
+        self.centroids[:, 2] *= scale   # x
+        self.centroids[:, 0] *= zscale  # z
+
+        dists = pdist(self.centroids)
+        avg_dist = dists.mean()
+
+        return avg_dist

--- a/pycroglia/core/centroid.py
+++ b/pycroglia/core/centroid.py
@@ -1,7 +1,6 @@
-from dataclasses import dataclass
 import numpy as np
 from  numpy.typing  import NDArray
-from scipy.spatial.distance import pdist, squareform
+from scipy.spatial.distance import pdist
 
 
 class Centroids:

--- a/pycroglia/core/tests/unit/test_centroid.py
+++ b/pycroglia/core/tests/unit/test_centroid.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+from pycroglia.core.centroid import Centroids
+
+
+def test_get_centroids():
+    """Test Centroids correctly computes centroids from binary masks.
+
+    Asserts:
+        The computed centroids match the expected voxel coordinates
+        for two simple 3D masks.
+    """
+    mask1 = np.zeros((3, 3, 3), dtype=np.uint8)
+    mask1[0, 0, 0] = 1
+    mask1[0, 1, 0] = 1
+    mask1[1, 0, 0] = 1
+    mask1[0, 0, 1] = 1
+
+    mask2 = np.zeros((3, 3, 3), dtype=np.uint8)
+    mask2[2, 2, 2] = 1
+    mask2[2, 1, 2] = 1
+    mask2[1, 2, 2] = 1
+    mask2[2, 2, 1] = 1
+
+    masks = [mask1, mask2]
+
+    c = Centroids(masks)
+    expected = np.array([np.array([0.25, 0.25, 0.25]), np.array([1.75, 1.75, 1.75])])
+    np.testing.assert_allclose(expected, c.centroids)
+
+
+def test_compute_average_centroid_distance():
+    """Test compute_average_distance returns correct scaled distance.
+
+    Asserts:
+        The average pairwise distance between two centroids is correctly
+        computed in physical units, given voxel scales for XY and Z.
+    """
+    zscale = 0.2
+    scale = 0.1
+
+    mask1 = np.zeros((3, 3, 3), dtype=np.uint8)
+    mask1[0, 0, 0] = 1
+    mask1[0, 1, 0] = 1
+    mask1[1, 0, 0] = 1
+    mask1[0, 0, 1] = 1
+
+    mask2 = np.zeros((3, 3, 3), dtype=np.uint8)
+    mask2[2, 2, 2] = 1
+    mask2[2, 1, 2] = 1
+    mask2[1, 2, 2] = 1
+    mask2[2, 2, 1] = 1
+
+    masks = [mask1, mask2]
+
+    c = Centroids(masks)
+    result = c.compute_average_distance(scale, zscale)
+
+    np.testing.assert_approx_equal(result, 0.3674234614174768)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
| #36 |

## Description

This PR introduces centroid-based analysis for segmented microglia cells.  
It enables computing voxel-space centroids for individual cells and calculating average pairwise distances between centroids in physical units, which can be used as a measure of cell density or dispersion.  

## Proposed Changes

- Add `Centroids` class to compute voxel centroids from binary masks.
- Implement `compute_average_distance` method with support for anisotropic voxel scaling (`scale` for XY and `zscale` for Z).
- Ensure consistent ordering of coordinates in `(z, y, x)` convention for compatibility with existing image processing pipelines.

### Results and Evidence

- Centroid coordinates correctly computed for toy masks with known voxel positions.
- Distance computations validated against expected scaled Euclidean distances.
- Average centroid distances match MATLAB reference implementation within numerical tolerance.
## Description

This PR introduces centroid-based analysis for segmented microglia cells.  
It enables computing voxel-space centroids for individual cells and calculating average pairwise distances between centroids in physical units, which can be used as a measure of cell density or dispersion.  

## Proposed Changes

- Add `Centroids` class to compute voxel centroids from binary masks.
- Implement `compute_average_distance` method with support for anisotropic voxel scaling (`scale` for XY and `zscale` for Z).
- Ensure consistent ordering of coordinates in `(z, y, x)` convention for compatibility with existing image processing pipelines.
- Provide robust handling of empty masks to avoid errors during centroid computation.

### Results and Evidence

- Centroid coordinates correctly computed for toy masks with known voxel positions.
- Distance computations validated against expected scaled Euclidean distances.
- Average centroid distances match MATLAB reference implementation within numerical tolerance.

### Manual tests with their corresponding evidence

- Verified matlab results against the python implementation ones, using the same mask. Next is an output run (note that matlab coords are (x, y, z) while python's are (z, y, x)
```
matlab centroids:
 [[ 394.90528179  272.13023753   16.14738861]
 [ 807.62673755  236.45008497   23.99742908]
 [ 465.79966142  580.04994036   22.898234  ]
 [ 637.99586207  788.0908046    31.31994253]
 [ 693.14412266  341.47175468   14.58936968]
 [ 689.93521638  329.08629179    6.32560249]
 [  18.71736334  699.25016077   20.08424437]
 [ 378.97359155  485.55213976   15.9646533 ]
 [ 218.74839516  400.55097957   34.62434348]
 [ 115.96717918  617.02365464    3.89473684]
 [1015.77361702  545.00198582   35.69985816]
 [ 412.69457364  180.30542636   10.16589147]
 [ 816.86044362  334.92513863   36.0896488 ]
 [ 881.13504823  212.42765273   11.00643087]
 [ 335.41055046  971.02408257    5.66743119]
 [ 724.58501441  236.29971182   21.20172911]
 [ 908.82121212  872.75757576   37.75454545]
 [ 741.84745763  322.86440678    5.57627119]
 [  40.57952756  778.18425197   36.10866142]
 [ 950.97609562  292.54581673   37.33864542]
 [ 420.88767123  395.07123288    5.04657534]
 [ 841.97674419  308.30232558   28.81395349]
 [ 172.32156863   88.58823529    4.30196078]
 [ 788.81327801  717.58921162    1.7593361 ]
 [1014.18529412  488.63235294   37.97352941]
 [ 735.5         774.42647059   27.80882353]
 [ 952.03015075  900.52261307   38.7839196 ]
 [ 391.15384615  998.76923077   25.30769231]
 [ 601.87878788  836.33333333   34.57575758]
 [ 478.5         322.18181818    3.86363636]
 [ 653.20930233  346.25581395    9.11627907]
 [1006.13907285  164.93377483   25.68874172]
 [  70.752       824.2          31.792     ]
 [ 459.58843537  643.42176871   24.93877551]
 [  61.70192308  683.37980769   30.15384615]
 [  11.43125     197.11875      30.38125   ]
 [ 798.          964.29166667   36.16666667]
 [ 122.00510204  561.15816327    4.96938776]
 [ 361.07619048 1018.47619048   30.72380952]
 [ 412.7         653.74         26.48      ]]
python centroids:
 [[ 394.90528179  272.13023753   16.14738861]
 [ 807.62673755  236.45008497   23.99742908]
 [ 465.79966142  580.04994036   22.898234  ]
 [ 637.99586207  788.0908046    31.31994253]
 [ 693.14412266  341.47175468   14.58936968]
 [ 689.93521638  329.08629179    6.32560249]
 [  18.71736334  699.25016077   20.08424437]
 [ 378.97359155  485.55213976   15.9646533 ]
 [ 218.74839516  400.55097957   34.62434348]
 [ 115.96717918  617.02365464    3.89473684]
 [1015.77361702  545.00198582   35.69985816]
 [ 412.69457364  180.30542636   10.16589147]
 [ 816.86044362  334.92513863   36.0896488 ]
 [ 881.13504823  212.42765273   11.00643087]
 [ 335.41055046  971.02408257    5.66743119]
 [ 724.58501441  236.29971182   21.20172911]
 [ 908.82121212  872.75757576   37.75454545]
 [ 741.84745763  322.86440678    5.57627119]
 [  40.57952756  778.18425197   36.10866142]
 [ 950.97609562  292.54581673   37.33864542]
 [ 420.88767123  395.07123288    5.04657534]
 [ 841.97674419  308.30232558   28.81395349]
 [ 172.32156863   88.58823529    4.30196078]
 [ 788.81327801  717.58921162    1.7593361 ]
 [1014.18529412  488.63235294   37.97352941]
 [ 735.5         774.42647059   27.80882353]
 [ 952.03015075  900.52261307   38.7839196 ]
 [ 391.15384615  998.76923077   25.30769231]
 [ 601.87878788  836.33333333   34.57575758]
 [ 478.5         322.18181818    3.86363636]
 [ 653.20930233  346.25581395    9.11627907]
 [1006.13907285  164.93377483   25.68874172]
 [  70.752       824.2          31.792     ]
 [ 459.58843537  643.42176871   24.93877551]
 [  61.70192308  683.37980769   30.15384615]
 [  11.43125     197.11875      30.38125   ]
 [ 798.          964.29166667   36.16666667]
 [ 122.00510204  561.15816327    4.96938776]
 [ 361.07619048 1018.47619048   30.72380952]
 [ 412.7         653.74         26.48      ]]
expected avg: 53.1606
got avg: 53.10128885164537
```
### Tests Introduced

- **Unit Tests**:
  - `test_get_centroids`: validates voxel centroid computation for multiple 3D masks.
  - `test_compute_average_centroid_distance`: validates average pairwise distance computation with voxel scaling.
- Tests ensure numerical correctness with floating-point comparisons.
- Coverage includes both centroid extraction and physical distance calculation.
### Tests Introduced

- **Unit Tests**:
  - `test_get_centroids`: validates voxel centroid computation for multiple 3D masks.
  - `test_compute_average_centroid_distance`: validates average pairwise distance computation with voxel scaling.
- Tests ensure numerical correctness with floating-point comparisons.
- Coverage includes both centroid extraction and physical distance calculation.
