### PR TITLE
Implemented BoundingBox functionality

### DIFF
--- a/pycroglia/core/bounding_box.py
+++ b/pycroglia/core/bounding_box.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass
+class ComputeResult:
+    bounded_img: NDArray
+    right: int
+    left: int
+    top: int
+    bottom: int
+
+
+def compute(input_img: NDArray) -> ComputeResult:
+    """Compute the tight bounding box of a 3D binary image along the Z and Y axes.
+
+    The function finds the minimum and maximum foreground voxel indices 
+    (value == 1 / True) along the Z (rows) and Y (columns) dimensions, 
+    crops the input volume accordingly, and keeps the full X (slices) range.  
+
+    Args:
+        input_img (NDArray):
+            A 3D boolean or uint8 array with shape (Z, Y, X).
+
+    Returns:
+        ComputeResult:
+            A dataclass with the following fields:
+            - bounded_img (NDArray): Cropped sub-volume 
+              [left:right+1, bottom:top+1, :].
+            - right (int): Max Z index (0-based).
+            - left (int): Min Z index (0-based).
+            - top (int): Max Y index (0-based).
+            - bottom (int): Min Y index (0-based).
+    """
+    assert input_img.ndim == 3, f"Expected a 3D array, got shape {input_img.shape}"
+
+    # Find foreground voxel coordinates
+    coords = np.argwhere(input_img)
+    if coords.size == 0:
+        raise ValueError("No foreground voxels found (all zeros).")
+
+    # coords columns correspond to (x, y, z) == (row, col, slice) in NumPy
+    z = coords[:, 0]
+    y = coords[:, 1]
+
+    z_min, z_max = int(z.min()), int(z.max())
+    y_min, y_max = int(y.min()), int(y.max())
+
+    bounded_img = input_img[z_min : z_max + 1, y_min : y_max + 1, :]
+
+    return ComputeResult(
+        bounded_img=bounded_img, right=z_max, left=z_min, top=y_max, bottom=y_min
+    )

--- a/pycroglia/core/tests/unit/test_bounding_box.py
+++ b/pycroglia/core/tests/unit/test_bounding_box.py
@@ -1,0 +1,32 @@
+import numpy as np
+from pycroglia.core import bounding_box
+
+
+def test_bounding_box_of_cell():
+    """
+    Test Bounding Box computation on a simple 3D volume.
+
+    Scenario:
+        A single foreground voxel is placed at (z=2, y=3, x=4) in a 
+        (5,6,7) volume. The bounding box should tightly crop in z and y,
+        while keeping the full x dimension.
+
+    Asserts:
+        - The cropped volume has shape (1, 1, 7), shrinking only in z and y.
+        - The bounding box z-bounds (left/right) are both 2.
+        - The bounding box y-bounds (bottom/top) are both 3.
+        - The voxel at the expected cropped coordinate is True.
+    """
+    # Create a 3D volume (z=5, y=6, x=7)
+    vol = np.zeros((5, 6, 7), dtype=bool)
+    vol[2, 3, 4] = True  # foreground voxel at (z=2, y=3, x=4)
+
+    result = bounding_box.compute(vol)
+
+    assert result.bounded_img.shape == (1, 1, 7), (
+        "Cropped volume should keep all x and shrink z,y"
+    )
+    assert result.left == 2 and result.right == 2, "Z bounds should match voxel z=2"
+    assert result.bottom == 3 and result.top == 3, "Y bounds should match voxel y=3"
+
+    assert result.bounded_img[0, 0, 4]


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
| #52 |

## Description

This pull request introduces the Python implementation of a **3D bounding box extraction** function, equivalent to the MATLAB `BoundingBoxOfCell`.  
The function crops a binary 3D volume to the smallest axis-aligned bounding box around all foreground voxels along Z and Y dimensions, keeping the full X range.

## Proposed Changes

- Added `bounding_box.compute` function that:
  - Finds the minimum and maximum voxel coordinates along Z and Y axes.
  - Returns a `ComputeResult` dataclass containing:
    - Cropped sub-volume (`bounded_img`)
    - Bounding box coordinates (`left`, `right`, `top`, `bottom`)
- Added `ComputeResult` dataclass to wrap outputs for clarity.
- Python version respects NumPy’s `(z, y, x)` indexing convention, while aligning behavior with MATLAB.

### Manual tests with their corresponding evidence

- Verified consistency between MATLAB and Python versions by applying both implementations to the same synthetic volume and comparing bounding box coordinates.

### Tests Introduced

- **Unit Test**:
  - `test_bounding_box_of_cell`: verifies correctness of cropped volume, bounding indices, and voxel preservation for a synthetic 3D input.