### PR TITLE
Feat/53 nearest pixel functionality

### DIFF
--- a/pycroglia/core/nearest_pixel.py
+++ b/pycroglia/core/nearest_pixel.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 @dataclass
 class Coordinates:
+    """Container for 3D voxel coordinates."""    
     x: int
     y: int
     z: int

--- a/pycroglia/core/nearest_pixel.py
+++ b/pycroglia/core/nearest_pixel.py
@@ -1,0 +1,54 @@
+import numpy as np
+from numpy.typing import NDArray
+from dataclasses import dataclass
+
+
+@dataclass
+class Coordinates:
+    x: int
+    y: int
+    z: int
+
+
+def compute(
+    img: NDArray, starting_pixel: tuple[int, int, int], scale: float
+) -> Coordinates:
+    """
+    Find the nearest foreground voxel (value=1) in a 3D binary image.
+
+    Args:
+        img (NDArray):
+            3D binary image of shape (z, y, x). Foreground voxels are 1 or True.
+        starting_pixel (tuple[int,int,int]):
+            Starting voxel coordinates in (z, y, x) order.
+        scale (float):
+            Anisotropy scaling factor applied equally to the z and y distances
+            (mimicking the MATLAB implementation).
+
+    Returns:
+        Coordinates:
+            Dataclass containing (x, y, z) of the closest foreground voxel.
+
+    Raises:
+        ValueError: If the image contains no foreground voxels.
+    """
+    # Foreground voxel coordinates
+    coords = np.argwhere(img == 1)
+
+    if coords.size == 0:
+        raise ValueError("No foreground voxels found.")
+
+    z0, y0, x0 = starting_pixel
+
+    # Apply anisotropic distance
+    diffs = coords - np.array([z0, y0, x0])
+    dists = np.sqrt(
+        (diffs[:, 1] * scale) ** 2  # y difference scaled
+        + (diffs[:, 0] * scale) ** 2  # z difference scaled
+        + (diffs[:, 2]) ** 2
+    )  # x difference unchanged
+
+    idx = np.argmin(dists)
+    z, y, x = coords[idx]
+
+    return Coordinates(x=int(x), y=int(y), z=int(z))

--- a/pycroglia/core/tests/unit/test_nearest_pixel.py
+++ b/pycroglia/core/tests/unit/test_nearest_pixel.py
@@ -1,0 +1,29 @@
+import numpy as np
+from pycroglia.core.nearest_pixel import compute, Coordinates
+
+
+def test_nearest_pixel():
+    """Test NearestPixel correctly finds the closest foreground voxel.
+
+    Scenario:
+        - A 5×5×5 binary volume is created with a single voxel set to True
+          at coordinates (z=2, y=3, x=4).
+        - The search starts at (0,0,0) with isotropic scale=1.0.
+
+    Asserts:
+        - The nearest voxel coordinates returned by `compute` match the
+          expected location (x=4, y=3, z=2).
+        - The returned result is equal to a NearestPixelCoordinates instance
+          with these values.
+    """
+
+    # Create a simple 5x5x5 volume
+    vol = np.zeros((5, 5, 5), dtype=bool)
+    vol[2, 3, 4] = True  # foreground voxel at (z=2, y=3, x=4)
+
+    result = compute(vol, (0, 0, 0), scale=1.0)
+
+    # Expected nearest voxel
+    expected = Coordinates(x=4, y=3, z=2)
+
+    assert result == expected, f"Expected {expected}, got {result}"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
|#53 |

## Description

This pull request introduces the Python implementation of the **`NearestPixel`** function, mirroring the behavior of the MATLAB version.  
It computes the nearest foreground voxel (value = 1) in a 3D binary image relative to a given starting voxel, with support for anisotropy scaling.  

The function returns results using a typed `Coordinates` dataclass to ensure clarity and type safety.  

## Proposed Changes

- Added `Coordinates` dataclass for 3D voxel coordinates `(x, y, z)`.
- Implemented `compute(img, starting_pixel, scale)` function:
  - Accepts a 3D binary image in NumPy `(z, y, x)` format.
  - Returns the nearest voxel as `Coordinates(x, y, z)`.
  - Includes anisotropy scaling for z and y distances.
- Added error handling for empty volumes (no foreground voxels).

### Manual tests with their corresponding evidence

- MATLAB and Python versions produce consistent results on small toy volumes.
- Verified anisotropy scaling parameter affects distance calculations as expected.

### Tests Introduced

- **Unit Test**:
  - `test_nearest_pixel`: validates that the Python implementation returns the expected nearest voxel given a synthetic 3D volume.
  - Uses a `5x5x5` test volume with a single foreground voxel.
  - Confirms the result matches `Coordinates(x=4, y=3, z=2)`.