### PR TITLE
Implemented ConnectionPointsAlongPath functionality

### DIFF
--- a/pycroglia/core/connection.py
+++ b/pycroglia/core/connection.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+from numpy.typing import NDArray
+from collections import deque
+import numpy as np
+
+@dataclass
+class Point:
+    """A 3D voxel coordinate in (x, y, z)."""
+    x: int
+    y: int
+    z: int
+
+# 26-neighbourhood offsets (all possible moves except staying in place)    
+NEIGHBOURS = [(dz,dy,dx) 
+                 for dz in (-1,0,1)
+                 for dy in (-1,0,1)
+                 for dx in (-1,0,1)
+                 if not (dz==dy==dx==0)]
+
+def connect_points_along_path(img: NDArray, start: Point, end: Point) -> NDArray:
+    """
+    Find the shortest path between two voxels constrained to foreground (True) voxels.
+
+    This function performs a **breadth-first search (BFS)** on a 3D binary volume to
+    trace the shortest path from `start` to `end`, moving only through connected
+    voxels that have value `True`.
+
+    Args:
+        img (NDArray): 3D binary array of shape (Z, Y, X).
+                       Foreground voxels must have value True.
+        start (Point): Starting voxel, given as (x, y, z).
+        end (Point): Ending voxel, given as (x, y, z).
+
+    Returns:
+        NDArray: Array of shape (N, 3) with the sequence of voxel coordinates
+                 forming the path, ordered as (z, y, x).
+                 If no path is found, returns an empty array.
+
+    Notes:
+        - Neighbourhood is 26-connected (includes diagonals).
+        - BFS guarantees the path found is the shortest in terms of voxel steps.
+        - The coordinate system is **0-based, z-y-x order** (NumPy convention).
+    """
+    assert img.ndim == 3, "the image should be 3D"
+    
+    shape = img.shape
+    visited = np.zeros(shape, dtype=bool)
+    prev = {}
+
+    # BFS queue
+    q = deque()
+    q.append((start.z, start.y, start.x))
+    visited[start.z, start.y, start.x] = True
+
+    found = False
+    while q:
+        z, y, x = q.popleft()
+        if (z, y, x) == (end.z, end.y, end.x):
+            found = True
+            break
+
+        for dz, dy, dx in NEIGHBOURS:
+            zn, yn, xn = z + dz, y + dy, x + dx
+            if (
+                0 <= zn < shape[0]
+                and 0 <= yn < shape[1]
+                and 0 <= xn < shape[2]
+                and img[zn, yn, xn]
+                and not visited[zn, yn, xn]
+            ):
+                visited[zn, yn, xn] = True
+                prev[(zn, yn, xn)] = (z, y, x)
+                q.append((zn, yn, xn))
+            
+    if not found:
+        return np.array([])
+
+    path = []
+    curr = (end.z, end.y, end.x)
+    while curr != (start.z, start.y, start.x):
+        path.append(curr)
+        curr = prev[curr]
+    path.append((start.z, start.y, start.x))
+    path.reverse()
+
+    return np.array(path, dtype=int)  # shape (N, 3), order (z, y, x)

--- a/pycroglia/core/tests/unit/test_connection.py
+++ b/pycroglia/core/tests/unit/test_connection.py
@@ -1,0 +1,95 @@
+import numpy as np
+from pycroglia.core.connection import connect_points_along_path, Point
+
+
+def test_path_not_found():
+    """Test that no path is found when start and end voxels are isolated.
+
+    Scenario:
+        - A 5x5x5 volume is created with only two voxels set to True,
+          at (2,1,1) and (2,3,3).
+        - Since there is no connecting chain of True voxels, the BFS
+          should fail to find a path.
+
+    Asserts:
+        - Returned path has size 0, indicating no connection exists.
+    """
+    vol = np.zeros((5, 5, 5), dtype=bool)
+    vol[2, 1, 1] = True
+    vol[2, 3, 3] = True
+
+    start = Point(x=1, y=1, z=2)
+    end = Point(x=3, y=3, z=2)
+
+    path = connect_points_along_path(vol, start, end)
+
+    assert path.size == 0, f"Expected empty array, got shape {path.shape}"
+
+
+def test_simple_diagonal_path():
+    """Test that a diagonal chain of voxels is traversed correctly.
+
+    Scenario:
+        - A 5x5x5 volume with a diagonal line of True voxels from
+          (0,0,0) to (4,4,4).
+        - Start = (0,0,0), End = (4,4,4).
+
+    Asserts:
+        - Path contains exactly 5 points.
+        - Path equals the diagonal sequence [[0,0,0], [1,1,1], ..., [4,4,4]].
+    """
+    vol = np.zeros((5, 5, 5), dtype=bool)
+    # diagonal from (0,0,0) to (4,4,4)
+    for i in range(5):
+        vol[i, i, i] = True
+
+    start = Point(x=0, y=0, z=0)
+    end = Point(x=4, y=4, z=4)
+
+    path = connect_points_along_path(vol, start, end)
+
+    # Path should cover 5 voxels along the diagonal
+    assert path.shape == (5, 3)
+    np.testing.assert_array_equal(path, np.array([[i, i, i] for i in range(5)]))
+
+
+def test_complex_path():
+    """Test that an L-shaped path is reconstructed correctly.
+
+    Scenario:
+        - A 5x5x5 volume with a path at z=2 forming:
+            (2,1,1) → (2,1,2) → (2,1,3) → (2,2,3) → (2,3,3).
+        - Start = (2,1,1), End = (2,3,3).
+
+    Asserts:
+        - Path follows the expected L-shape.
+        - Path equals [[2,1,1], [2,1,2], [2,2,3], [2,3,3]].
+    """
+    # Create a 5x5x5 volume
+    img = np.zeros((5, 5, 5), dtype=bool)
+
+    # Build an L-shaped path at z=2:
+    # from (2,1,1) → (2,1,2) → (2,1,3) → (2,2,3) → (2,3,3)
+    img[2, 1, 1] = True
+    img[2, 1, 2] = True
+    img[2, 1, 3] = True
+    img[2, 2, 3] = True
+    img[2, 3, 3] = True
+
+    start = Point(x=1, y=1, z=2)
+    end = Point(x=3, y=3, z=2)
+
+    path = connect_points_along_path(img, start, end)
+
+    # Expected path in order (z,y,x)
+    expected = np.array(
+        [
+            [2, 1, 1],
+            [2, 1, 2],
+            [2, 2, 3],
+            [2, 3, 3],
+        ],
+        dtype=int,
+    )
+
+    np.testing.assert_array_equal(path, expected)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
|#54 |

## Description

This pull request introduces the Python implementation of `connect_points_along_path`,  
a utility to trace the shortest path between two points constrained to the skeleton (foreground voxels).  
It mirrors the behavior of the MATLAB `ConnectPointsAlongPath` function but adapts it to Python conventions  
(0-based indexing, NumPy arrays in z-y-x order).

## Proposed Changes

- Added `Point` dataclass to represent voxel coordinates `(x, y, z)`.
- Implemented `connect_points_along_path` using BFS:
  - Returns the shortest path as a NumPy array of shape `(N, 3)`.
  - Path is constrained to foreground voxels (`True`).
  - Returns an empty array if no path exists.
- Added 26-connected neighbourhood support for pathfinding.
- Documented function with detailed docstrings and usage notes.

### Manual tests with their corresponding evidence

- Confirmed correctness by comparing with MATLAB implementation:
  - Python and MATLAB produced matching paths (with index offset due to 0-based vs 1-based).
  
### Tests Introduced

- **Unit Tests**:
 - `test_path_not_found`: ensures empty path when start/end disconnected.
 - `test_simple_diagonal_path`: verifies diagonal path reconstruction.
 - `test_complex_path`: validates L-shaped path through skeleton voxels.

These tests provide coverage for both failure and success cases of pathfinding.