### PR TITLE
Bug/100 erroneous handling of small cells

### DIFF
--- a/pycroglia/core/branch_analysis.py
+++ b/pycroglia/core/branch_analysis.py
@@ -9,8 +9,10 @@ import pycroglia.core.nearest_pixel as nearest_pixel
 import pycroglia.core.connection as connection
 import numpy as np
 
+
 class EmptySkeleton(Exception):
     """Raised when a skeleton or image has no nonzero voxels (i.e., is empty)."""
+
     pass
 
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
| #100|

## Description

The spurious exceptions were raised due to some errors in branch analysis. As a brief summary of the issue, small cells were generating empty skeletons (due to them being inferior to the thinning threshold), which broke a precondition in bounding box module, rasing an exception. Sometimes this cells survived but didn't make an arc but due to using the wrong check, metrics were being computed anyway breaking the preconditions of np.max(), and also raising an exception.

-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->
* Added check for empty skeleton, now it raises EmptySkeleton exception
* Fixed check of arclengths

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

Passing tests
```
========================================== test session starts ==========================================
platform linux -- Python 3.10.12, pytest-8.4.1, pluggy-1.6.0
PyQt6 6.9.1 -- Qt runtime 6.9.1 -- Qt compiled 6.9.0
rootdir: /home/wave/dev/pycroglia
configfile: pyproject.toml
plugins: memray-1.8.0, qt-4.5.0
collected 245 items                                                                                     

pycroglia/core/compute/tests/unit/test_mp_pool.py ....                                            [  1%]
pycroglia/core/compute/tests/unit/test_qt_pool.py ....                                            [  3%]
pycroglia/core/io/tests/unit/test_output.py ....................                                  [ 11%]
pycroglia/core/io/tests/unit/test_readers.py ..................................                   [ 25%]
pycroglia/core/skeletonize/tests/unit/test_msfm.py ..                                             [ 26%]
pycroglia/core/skeletonize/tests/unit/test_rt.py ...                                              [ 27%]
pycroglia/core/skeletonize/tests/unit/test_skeleton.py .                                          [ 27%]
pycroglia/core/slimskel3d/tests/unit/test_graph2skel.py .                                         [ 28%]
pycroglia/core/slimskel3d/tests/unit/test_skel2graph.py .                                         [ 28%]
pycroglia/core/slimskel3d/tests/unit/test_skeleton3D.py .                                         [ 28%]
pycroglia/core/slimskel3d/tests/unit/test_slimskel3d.py .                                         [ 29%]
pycroglia/core/tests/integration/test_readers.py ....                                             [ 31%]
pycroglia/core/tests/unit/test_arclength.py ...                                                   [ 32%]
pycroglia/core/tests/unit/test_bounding_box.py .                                                  [ 32%]
pycroglia/core/tests/unit/test_branch_analysis.py .                                               [ 33%]
pycroglia/core/tests/unit/test_centroid.py ..                                                     [ 33%]
pycroglia/core/tests/unit/test_clustering.py .....                                                [ 35%]
pycroglia/core/tests/unit/test_connection.py ...                                                  [ 37%]
pycroglia/core/tests/unit/test_erosion.py ............                                            [ 42%]
pycroglia/core/tests/unit/test_filters.py ...........                                             [ 46%]
pycroglia/core/tests/unit/test_full_cell_analysis.py .                                            [ 46%]
pycroglia/core/tests/unit/test_labeled_cells.py ...........................                       [ 57%]
pycroglia/core/tests/unit/test_nearest_pixel.py .                                                 [ 58%]
pycroglia/core/tests/unit/test_reorder.py ..                                                      [ 59%]
pycroglia/core/tests/unit/test_segmentation.py ....                                               [ 60%]
pycroglia/core/tests/unit/test_territorial_volume.py ..                                           [ 61%]
pycroglia/ui/widgets/analysis/tests/test_cell_selector.py ......................                  [ 70%]
pycroglia/ui/widgets/analysis/tests/test_dialog.py ....                                           [ 72%]
pycroglia/ui/widgets/cells/tests/test_cell_list.py ......                                         [ 74%]
pycroglia/ui/widgets/cells/tests/test_cells_panel.py ......                                       [ 77%]
pycroglia/ui/widgets/cells/tests/test_multi_cell_img_viewer.py .                                  [ 77%]
pycroglia/ui/widgets/common/tests/test_img_viewer.py ..                                           [ 78%]
pycroglia/ui/widgets/common/tests/test_labeled_widgets.py ...........                             [ 82%]
pycroglia/ui/widgets/common/tests/test_two_column_list.py ........                                [ 86%]
pycroglia/ui/widgets/imagefilters/tests/test_configurator.py ...                                  [ 87%]
pycroglia/ui/widgets/imagefilters/tests/test_editors.py ....                                      [ 88%]
pycroglia/ui/widgets/imagefilters/tests/test_loader.py .                                          [ 89%]
pycroglia/ui/widgets/imagefilters/tests/test_results.py .                                         [ 89%]
pycroglia/ui/widgets/imagefilters/tests/test_stacks.py .....                                      [ 91%]
pycroglia/ui/widgets/imagefilters/tests/test_tasks.py ....                                        [ 93%]
pycroglia/ui/widgets/io/tests/test_file_selection_editor.py .....                                 [ 95%]
pycroglia/ui/widgets/io/tests/test_file_selector.py ..                                            [ 96%]
pycroglia/ui/widgets/segmentation/tests/test_editor.py ....                                       [ 97%]
pycroglia/ui/widgets/segmentation/tests/test_stacks.py .....                                      [100%]

=========================================== warnings summary ============================================
pycroglia/core/tests/unit/test_filters.py::test_remove_small_object_filter_object
pycroglia/core/tests/unit/test_filters.py::test_keep_large_object_dont_filter_object
pycroglia/core/tests/unit/test_filters.py::test_remove_small_objects_connectivity[SkimageCellConnectivity.EDGES-3]
pycroglia/core/tests/unit/test_filters.py::test_remove_small_objects_connectivity[SkimageCellConnectivity.CORNERS-3]
pycroglia/core/tests/unit/test_filters.py::test_remove_small_objects_dtype_uint8
pycroglia/core/tests/unit/test_filters.py::test_remove_small_objects_object_on_border
pycroglia/core/tests/unit/test_segmentation.py::test_segment_single_cell_split
  /home/wave/dev/pycroglia/pycroglia/core/filters.py:55: UserWarning: Only one label was provided to `remove_small_objects`. Did you mean to use a boolean array?
    filtered = skimage.morphology.remove_small_objects(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== 245 passed, 7 warnings in 19.72s ====================================
```