### PR TITLE
Feat/102 add cancellation to pool

### DIFF
--- a/pycroglia/core/compute/backend.py
+++ b/pycroglia/core/compute/backend.py
@@ -17,7 +17,7 @@ class Task(Protocol):
         """
         ...
 
-        
+
 class Backend(Protocol):
     """Protocol for computation backends.
 

--- a/pycroglia/core/compute/mp_pool.py
+++ b/pycroglia/core/compute/mp_pool.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import Any
 from pycroglia.core.compute.computable import Computable
 
+
 class CancelFlag:
     """Lightweight cooperative cancellation flag for multiprocessing tasks.
 
@@ -39,15 +40,17 @@ class CancelFlag:
         """
         return self._cancelled.value
 
+
 class MPTask:
-   """A multiprocessing-compatible task that executes a Computable.
+    """A multiprocessing-compatible task that executes a Computable.
 
     Attributes:
         task_id (str): Unique identifier for this task.
         computable (Computable): The computation object to run.
         cancel_flag (CancelFlag): Shared cancellation flag.
     """
-   def __init__(self, computable: Computable, cancel_flag: CancelFlag) -> None:
+
+    def __init__(self, computable: Computable, cancel_flag: CancelFlag) -> None:
         """Initialize the multiprocessing task.
 
         Args:
@@ -58,7 +61,7 @@ class MPTask:
         self.computable = computable
         self.cancel_flag = cancel_flag
 
-   def run(self):
+    def run(self):
         """Execute the computable and return its result.
 
         The Computable is responsible for checking `cancel_flag.is_set()`
@@ -73,7 +76,6 @@ class MPTask:
             return self.computable.compute()
         except Exception as e:
             raise e
-
 
 
 class MPPool:
@@ -156,7 +158,7 @@ class MPPool:
         check it will terminate gracefully. Pending tasks are ignored.
         """
         self.cancel_flag.set()
-        
+
     def _decrement_pending(self) -> None:
         """Track task completion and trigger all_finished if done."""
         self.pending -= 1

--- a/pycroglia/core/compute/pool.py
+++ b/pycroglia/core/compute/pool.py
@@ -50,7 +50,7 @@ class Pool:
     def cancel(self) -> None:
         """Cancels execution of all submitted tasks."""
         return self.backend.cancel()
-    
+
     def join(self) -> None:
         """Block until all tasks are finished."""
         return self.backend.join()

--- a/pycroglia/core/compute/qt_pool.py
+++ b/pycroglia/core/compute/qt_pool.py
@@ -4,12 +4,13 @@ import uuid
 from PyQt6.QtCore import QObject, QRunnable, QThreadPool, pyqtSignal, pyqtSlot
 from pycroglia.core.compute.computable import Computable
 
+
 class CancelFlag:
     """Lightweight cooperative cancellation flag for task management.
 
     This class provides a simple mechanism for signalling cooperative
     cancellation between a task backend (e.g., QThreadPool) and the
-    tasks it executes. 
+    tasks it executes.
 
     Attributes:
         cancelled (bool): Internal state indicating whether cancellation
@@ -73,8 +74,8 @@ class QTask(QRunnable):
         self.task_id = uuid.uuid4().hex
         self.computable = computable
         self.signals = QTaskSignal()
-        self.cancel_flag= flag
-        
+        self.cancel_flag = flag
+
     @pyqtSlot()
     def run(self):
         """Execute the task, unless the cancel flag is set.
@@ -114,7 +115,7 @@ class QPool(QObject):
         self.tasks = []
         self.pending = 0
         self.cancel_flag = CancelFlag()
-        
+
     def submit(
         self,
         computable: Computable,
@@ -156,7 +157,7 @@ class QPool(QObject):
     def cancel(self):
         """Cancels execution of all submitted tasks."""
         self.cancel_flag.set()
-        
+
     def _on_task_finished(
         self, callback: Callable[[str], None] | None = None
     ) -> Callable[[str], None]:

--- a/pycroglia/core/compute/tests/unit/test_mp_pool.py
+++ b/pycroglia/core/compute/tests/unit/test_mp_pool.py
@@ -177,6 +177,7 @@ def test_pool_cancellation():
         The `all_finished` callback is executed once after cancellation.
         The internal `tasks` list is cleared when all tasks have finished or been cancelled.
     """
+
     class SlowComputable(DummyComputable):
         def compute(self) -> dict[str, Any]:
             return {"cell_id": self.cell_id, "value": self.cell_id * 10}

--- a/pycroglia/core/compute/tests/unit/test_qt_pool.py
+++ b/pycroglia/core/compute/tests/unit/test_qt_pool.py
@@ -149,6 +149,7 @@ def test_all_finished_emitted_once(qtbot):
 
     assert finished_signal_count == 1
 
+
 def test_pool_cancellation(qtbot):
     """Test that QPool cooperatively cancels running tasks.
 
@@ -180,4 +181,4 @@ def test_pool_cancellation(qtbot):
     assert pool.cancel_flag.is_set()
     assert not results
     assert len(finished_called) == 3
-    assert not pool.tasks    
+    assert not pool.tasks


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
|#102 |

This pull request introduces a unified and robust cancellation mechanism across all computation backends (`QPool`,an `MPPool` variants).  
The main goal is to ensure that cancellation requests cleanly propagate through all submitted tasks, while preserving completion tracking and consistent signaling behavior.
## Proposed Changes

- **Refactored `CancelFlag`**
  - Implemented a lightweight cooperative cancellation flag.
  - Ensured consistent behavior across `QPool` and `MPPool` 
  - Uses atomic access for cancellation checks in multithreaded and multiprocess backends.

- **Updated `QPool` (PyQt-based thread pool)**
  - Tasks now always emit `finished` even when cancelled before running.
  - Guarantees `all_finished` is emitted when `pending == 0`, avoiding test hangs.
  - Simplified lifecycle: `submit → run → join` with graceful flag propagation.
  - Added comprehensive `pytest-qt` test coverage (`test_qpool_*`).

- **Refactored `MPPool`**
  - Added shared `CancelFlag` for cooperative cancellation using `ctx.Value`.
  - Ensured `_decrement_pending()` always runs via `finally`, guaranteeing completion even on cancel or error.
  - Verified through extended test coverage (`test_pool_cancellation`, `test_multiple_tasks_success`, etc.).
  - Replaced `multiprocessing.Pool` with `multiprocessing.pool.ThreadPool` for lightweight execution.
  - Retains same interface and cancellation semantics.
  - Avoids pickling overhead for `Computable` objects.

