### PR TITLE
Added new publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: "Publish"
+
+on:
+  push:
+    tags:
+      # Publish on any tag starting with a `v`, e.g., v0.1.0
+      - v*
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install Python 3.13
+        run: uv python install 3.13
+      - name: Build
+        run: uv build
+      # Check that basic features work and we didn't miss to include crucial files
+      - name: Smoke test (wheel)
+        run: uv run --isolated --no-project --with dist/*.whl smoke_test.py
+      - name: Smoke test (source distribution)
+        run: uv run --isolated --no-project --with dist/*.tar.gz smoke_test.py
+      - name: Publish
+        run: uv publish

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,0 +1,6 @@
+def test_import():
+    import pycroglia
+    assert hasattr(pycroglia, "__version__")
+
+if __name__ == "__main__":
+    test_import()


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
-->

<!---
If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

| Related Issue |
|---|
|#108|

## Description

This pull request adds a **continuous delivery pipeline** for automated PyPI publishing using **`uv`**.  
The workflow builds the package, runs smoke tests against both the wheel and source distributions, and publishes the release to PyPI whenever a new version tag (e.g., `v1.2.3`) is pushed.

This change ensures that every tagged version of `pycroglia` is automatically built, validated, and distributed, streamlining release management and reducing manual intervention.

## Proposed Changes

- Added a new GitHub Actions workflow `.github/workflows/publish.yml`:
  - Triggers on version tags (`v*`)
  - Installs `uv` and Python 3.13
  - Builds both wheel and sdist packages
  - Runs smoke tests on the generated artifacts
  - Publishes the release to PyPI using OpenID Connect (no password required)
- Added `smoke_test.py` at the repository root to validate import and version metadata.
- Updated workflow commands to point to `smoke_test.py` instead of `tests/smoke_test.py`.

## Tests Introduced

No new tests introduced.