### PR TITLE
calculate button and preview button

### DIFF
--- a/pycroglia/ui/controllers/dashboard_state.py
+++ b/pycroglia/ui/controllers/dashboard_state.py
@@ -358,20 +358,7 @@ class ResultsDashboardState(QtCore.QObject):
 
     @staticmethod
     def _make_default_per_cell() -> List[CellAnalysis]:
-        return [
-            CellAnalysis(
-                cell_territory_volume=0,
-                cell_volume=0,
-                ramification_index=0,
-                number_of_endpoints=0,
-                number_of_branches=0,
-                avg_branch_length=0,
-                max_branch_length=0,
-                min_branch_length=0,
-                full_cell_analysis={},
-                branch_analysis={},
-            )
-        ]
+        return []
 
     def __init__(
         self,

--- a/pycroglia/ui/widgets/results/dashboard.py
+++ b/pycroglia/ui/widgets/results/dashboard.py
@@ -107,6 +107,7 @@ class ResultsDashboard(QtWidgets.QWidget):
             cells_config=self._text_config.get_per_cell_text_config(),
             parent=self,
         )
+        self.table.setEnabled(False)  # Initially disabled until calculation finishes
 
         return self
 
@@ -271,6 +272,8 @@ class ResultsDashboard(QtWidgets.QWidget):
         """
         self.scales.disable_button()
         self.configurator.set_results_ready(False)
+        self.graphs.set_results_ready(False)
+        self.table.setEnabled(False)
         self._state.calculate_results(
             scale=self.scales.get_scale(),
             z_scale=self.scales.get_z_scale(),
@@ -288,14 +291,15 @@ class ResultsDashboard(QtWidgets.QWidget):
         """
 
         cells = self._state.get_per_cell()
-        self._graphs_generator.generate_plots(
-            selected_plots,
-            self.cell_masks,
-            cells[0].branch_analysis,
-            cells[0].full_cell_analysis,
-            self.scales.get_scale(),
-            self.scales.get_z_scale(),
-        )
+        if cells:
+            self._graphs_generator.generate_plots(
+                selected_plots,
+                self.cell_masks,
+                cells[0].branch_analysis,
+                cells[0].full_cell_analysis,
+                self.scales.get_scale(),
+                self.scales.get_z_scale(),
+            )
 
     def _update_results_view(self):
         """Refresh the results viewer widgets with the latest computed data.
@@ -307,8 +311,10 @@ class ResultsDashboard(QtWidgets.QWidget):
         self.table.update_data(
             summary=self._state.get_summary(), cells=self._state.get_per_cell()
         )
+        self.table.setEnabled(True)
         self.scales.enable_button()
         self.configurator.set_results_ready(True)
+        self.graphs.set_results_ready(True)
 
     @QtCore.pyqtSlot(int, int)
     def _on_progress_changed(self, completed: int, total: int):
@@ -334,6 +340,6 @@ class ResultsDashboard(QtWidgets.QWidget):
     ):
         summary = self._state.get_summary()
         cells = self._state.get_per_cell()
-
-        for writer in writers:
-            writer().write(os.path.join(folder, path), FullAnalysis(summary, cells))
+        if cells:
+            for writer in writers:
+                writer().write(os.path.join(folder, path), FullAnalysis(summary, cells))

--- a/pycroglia/ui/widgets/results/graphs.py
+++ b/pycroglia/ui/widgets/results/graphs.py
@@ -43,6 +43,7 @@ class GraphSelectionWidget(QtWidgets.QWidget):
             QtWidgets.QCheckBox(name, parent=self) for name in graphs_list
         ]
         self.button = QtWidgets.QPushButton(self.button_txt, parent=self)
+        self.button.setEnabled(False)  # Initially disabled until results are ready
 
         # Connections
         self.button.clicked.connect(self._on_button_clicked)
@@ -74,3 +75,11 @@ class GraphSelectionWidget(QtWidgets.QWidget):
         """
         list_of_graphs = self.get_selected_graphs()
         self.buttonClicked.emit(list_of_graphs)
+
+    def set_results_ready(self, ready: bool):
+        """Enable or disable the preview button.
+
+        Args:
+            ready (bool): Whether results are ready to be previewed.
+        """
+        self.button.setEnabled(ready)

--- a/pycroglia/ui/widgets/results/scale.py
+++ b/pycroglia/ui/widgets/results/scale.py
@@ -35,14 +35,20 @@ class ScaleConfigWidget(QtWidgets.QWidget):
         self._z_scale_txt = z_scale_txt or self.DEFAULT_Z_SCALE_TXT
         self._button_txt = button_txt or self.DEFAULT_BUTTON_TXT
 
+        self._is_calculating = False
+
         # Widgets
         self._scale = LabeledFloatSpinBox(
-            self._scale_txt, min_value=1e-7, decimals=3, parent=self
+            self._scale_txt, min_value=0.0, decimals=3, parent=self
         )
         self._z_scale = LabeledFloatSpinBox(
-            self._z_scale_txt, min_value=1e-7, decimals=3, parent=self
+            self._z_scale_txt, min_value=0.0, decimals=3, parent=self
         )
         self._button = QtWidgets.QPushButton(self._button_txt, parent=self)
+
+        self._scale.valueChanged.connect(self._update_button_state)
+        self._z_scale.valueChanged.connect(self._update_button_state)
+        self._update_button_state()
 
         # Layout
         layout = QtWidgets.QVBoxLayout()
@@ -79,13 +85,20 @@ class ScaleConfigWidget(QtWidgets.QWidget):
         """
         return self.get_scale() * self.get_scale() * self.get_z_scale()
 
+    def _update_button_state(self, _=None):
+        """Update button state based on scale values and computing status."""
+        has_valid_scales = self.get_scale() > 0.0 and self.get_z_scale() > 0.0
+        self._button.setEnabled(has_valid_scales and not self._is_calculating)
+
     def disable_button(self):
         """Disable the calculate button to prevent user interaction."""
-        self._button.setEnabled(False)
+        self._is_calculating = True
+        self._update_button_state()
 
     def enable_button(self):
         """Enable the calculate button to allow user interaction."""
-        self._button.setEnabled(True)
+        self._is_calculating = False
+        self._update_button_state()
 
     @property
     def clicked(self) -> QtCore.pyqtSignal:

--- a/pycroglia/ui/widgets/results/viewers.py
+++ b/pycroglia/ui/widgets/results/viewers.py
@@ -151,7 +151,8 @@ class CellAnalysisViewer(QtWidgets.QWidget):
         self.selector.currentIndexChanged.connect(self.update_table)
 
         # Setup
-        self.update_table(0)
+        if self.cells:
+            self.update_table(0)
 
     def update_table(self, idx: int):
         """Update the table to show data for the selected cell.
@@ -160,6 +161,9 @@ class CellAnalysisViewer(QtWidgets.QWidget):
             idx (int): Index of the selected cell.
         """
         self.table.clear()
+
+        if not self.cells:
+            return
 
         cell = self.cells[idx]
 


### PR DESCRIPTION
The calculate button is enabled when the scales are greater than 0; otherwise, it is disabled.
The preview button is enabled when the calculation is complete.
The tables are displayed empty and disabled before the calculated data is entered.