### PR TITLE
Erosion UI (Advance config) Added  and Segmentation Error Handling

### DIFF
--- a/pycroglia/ui/controllers/segmentation_state.py
+++ b/pycroglia/ui/controllers/segmentation_state.py
@@ -22,14 +22,12 @@ class SegmentationEditorState(QtCore.QObject):
 
     Attributes:
         ARRAY_ELEMENTS_TYPE (type): Data type for output arrays.
-        DEFAULT_EROSION_FOOTPRINT (FootprintShape): Default structuring element for erosion.
         DEFAULT_SKIMAGE_CONNECTIVITY (SkimageCellConnectivity): Default connectivity for labeling.
         DEFAULT_PROGRESS_BAR_TEXT (str): Default text for the progress bar.
     """
 
     ARRAY_ELEMENTS_TYPE = np.uint8
 
-    DEFAULT_EROSION_FOOTPRINT = Diamond2DFootprint(r=3)
     DEFAULT_SKIMAGE_CONNECTIVITY = SkimageCellConnectivity.CORNERS
 
     DEFAULT_PROGRESS_BAR_TEXT = "Processing cells..."
@@ -54,6 +52,7 @@ class SegmentationEditorState(QtCore.QObject):
         img: NDArray,
         labeling_strategy: LabelingStrategy,
         min_size: int,
+        erosion_radius: int = 3,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         """Initializes the segmentation editor state.
@@ -62,6 +61,7 @@ class SegmentationEditorState(QtCore.QObject):
             img (NDArray): 3D binary image.
             labeling_strategy (LabelingStrategy): Strategy for labeling connected components.
             min_size (int): Minimum size for objects to keep after noise removal.
+            erosion_radius (int): Radius for the diamond erosion footprint. Default is 3.
             parent (Optional[QtWidgets.QWidget], optional): Parent widget. Defaults to None.
         """
         super().__init__(parent=parent)
@@ -71,6 +71,7 @@ class SegmentationEditorState(QtCore.QObject):
         self._actual_state = LabeledCells(img, labeling_strategy)
         self._prev_state: Optional[LabeledCells] = None
         self._min_size = min_size
+        self._erosion_footprint = Diamond2DFootprint(r=erosion_radius)
 
     def get_state(self) -> LabeledCells:
         """Returns the current segmentation state.
@@ -134,7 +135,7 @@ class SegmentationEditorState(QtCore.QObject):
             if cell_index == i:
                 segmented_cell = segment_single_cell(
                     cell_matrix=self._actual_state.get_cell(i),
-                    footprint=self.DEFAULT_EROSION_FOOTPRINT,
+                    footprint=self._erosion_footprint,
                     config=SegmentationConfig(
                         cut_off_size=cell_size,
                         min_size=self._min_size,

--- a/pycroglia/ui/widgets/imagefilters/editors.py
+++ b/pycroglia/ui/widgets/imagefilters/editors.py
@@ -281,6 +281,7 @@ class FilterResults:
         gray_filter_value: float,
         min_size: int,
         small_object_filtered_img: NDArray,
+        erosion_radius: int = 3,
     ):
         """
         Args:
@@ -288,11 +289,13 @@ class FilterResults:
             gray_filter_value (float): Value used for the gray filter.
             min_size (int): Minimum size for small object removal.
             small_object_filtered_img (np.ndarray): Image after small object removal.
+            erosion_radius (int): Radius for the diamond erosion footprint. Default is 3.
         """
         self.file_path = file_path
         self.gray_filter_value = gray_filter_value
         self.min_size = min_size
         self.small_object_filtered_img = small_object_filtered_img
+        self.erosion_radius = erosion_radius
 
     def as_dict(self) -> dict:
         """Returns the filter results as a dictionary.
@@ -305,7 +308,82 @@ class FilterResults:
             "gray_filter_value": self.gray_filter_value,
             "min_size": self.min_size,
             "small_object_filtered_img": self.small_object_filtered_img,
+            "erosion_radius": self.erosion_radius,
         }
+
+
+class CollapsibleSection(QtWidgets.QWidget):
+    """A widget with a clickable header that shows/hides its content area.
+
+    Use :meth:`content_layout` to add child widgets. Future advanced settings
+    can be appended to the same section without touching the parent widget.
+
+    Attributes:
+        toggle_button (QToolButton): Clickable header that expands/collapses the section.
+        content_area (QWidget): Container widget whose visibility is toggled.
+        content_layout (QVBoxLayout): Layout inside the content area for adding children.
+    """
+
+    DEFAULT_COLLAPSED_ICON = "▶"
+    DEFAULT_EXPANDED_ICON = "▼"
+
+    def __init__(
+        self,
+        title: str = "Advanced Configuration",
+        expanded: bool = False,
+        parent: QtWidgets.QWidget | None = None,
+    ):
+        """Initialize the collapsible section.
+
+        Args:
+            title (str): Text shown in the toggle header button.
+            expanded (bool): Whether the section starts expanded. Default is False.
+            parent (QtWidgets.QWidget | None): Parent widget.
+        """
+        super().__init__(parent=parent)
+
+        self._expanded = expanded
+
+        # Toggle button acting as header
+        self.toggle_button = QtWidgets.QToolButton(parent=self)
+        self.toggle_button.setCheckable(True)
+        self.toggle_button.setChecked(expanded)
+        self.toggle_button.setToolButtonStyle(
+            QtCore.Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+        )
+        self.toggle_button.setArrowType(
+            QtCore.Qt.ArrowType.DownArrow if expanded else QtCore.Qt.ArrowType.RightArrow
+        )
+        self.toggle_button.setText(title)
+        self.toggle_button.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+
+        # Content area
+        self.content_area = QtWidgets.QWidget(parent=self)
+        self.content_area.setVisible(expanded)
+        self.content_layout = QtWidgets.QVBoxLayout()
+        self.content_layout.setContentsMargins(12, 4, 4, 4)
+        self.content_area.setLayout(self.content_layout)
+
+        # Outer layout
+        outer = QtWidgets.QVBoxLayout()
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+        outer.addWidget(self.toggle_button)
+        outer.addWidget(self.content_area)
+        self.setLayout(outer)
+
+        self.toggle_button.clicked.connect(self._on_toggle)
+
+    def _on_toggle(self, checked: bool):
+        """Show or hide the content area and update the arrow direction."""
+        self._expanded = checked
+        self.content_area.setVisible(checked)
+        self.toggle_button.setArrowType(
+            QtCore.Qt.ArrowType.DownArrow if checked else QtCore.Qt.ArrowType.RightArrow
+        )
 
 
 class MultiChannelFilterEditor(QtWidgets.QWidget):
@@ -317,7 +395,13 @@ class MultiChannelFilterEditor(QtWidgets.QWidget):
         img_viewer (MultiChannelImageViewer): Widget for image viewing.
         gray_filter_editor (GrayFilterEditor): Widget for gray filter editing.
         small_object_filter_editor (SmallObjectsFilterEditor): Widget for small object filtering.
+        erosion_spin_box (LabeledIntSpinBox): Spin box for erosion radius.
     """
+
+    DEFAULT_EROSION_LABEL_TEXT = "Erosion"
+    DEFAULT_EROSION_RADIUS = 3
+    EROSION_MIN_VALUE = 1
+    EROSION_MAX_VALUE = 20
 
     def __init__(
         self,
@@ -330,6 +414,7 @@ class MultiChannelFilterEditor(QtWidgets.QWidget):
         gray_filter_slider_label: Optional[str] = None,
         small_objects_filter_label: Optional[str] = None,
         small_objects_threshold_label: Optional[str] = None,
+        erosion_label: Optional[str] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         """Initialize the multi-channel filter editor.
@@ -344,6 +429,7 @@ class MultiChannelFilterEditor(QtWidgets.QWidget):
             gray_filter_slider_label (Optional[str]): Label for gray filter slider.
             small_objects_filter_label (Optional[str]): Label text for small objects filter editor.
             small_objects_threshold_label (Optional[str]): Label for threshold spin box.
+            erosion_label (Optional[str]): Label for the erosion radius spin box.
             parent (Optional[QtWidgets.QWidget]): Parent widget.
         """
         super().__init__(parent=parent)
@@ -372,12 +458,45 @@ class MultiChannelFilterEditor(QtWidgets.QWidget):
             threshold_label_text=small_objects_threshold_label,
             parent=self,
         )
+        self.erosion_spin_box = LabeledIntSpinBox(
+            label_text=erosion_label or self.DEFAULT_EROSION_LABEL_TEXT,
+            min_value=self.EROSION_MIN_VALUE,
+            max_value=self.EROSION_MAX_VALUE,
+            parent=self,
+        )
+        self.erosion_spin_box.spin_box.setValue(self.DEFAULT_EROSION_RADIUS)
+
+        # Erosion info label inside the advanced section
+        self.erosion_info_label = QtWidgets.QLabel(
+            "\u2139\ufe0f  This setting is used in the next window to segment cells.",
+            parent=self,
+        )
+        self.erosion_info_label.setWordWrap(True)
+        _font = self.erosion_info_label.font()
+        _font.setItalic(True)
+        self.erosion_info_label.setFont(_font)
+
+        erosion_row = QtWidgets.QHBoxLayout()
+        erosion_row.addWidget(self.erosion_spin_box)
+        erosion_row.addWidget(self.erosion_info_label, stretch=1)
+        erosion_widget = QtWidgets.QWidget(parent=self)
+        erosion_widget.setLayout(erosion_row)
+
+        # Advanced configuration collapsible section
+        self.advanced_section = CollapsibleSection(
+            title="Advanced Configuration", expanded=False, parent=self
+        )
+        self.advanced_section.content_layout.addWidget(erosion_widget)
 
         # Layout
-        layout = QtWidgets.QHBoxLayout()
-        layout.addWidget(self.img_viewer, stretch=1)
-        layout.addWidget(self.gray_filter_editor, stretch=1)
-        layout.addWidget(self.small_object_filter_editor, stretch=1)
+        filter_row = QtWidgets.QHBoxLayout()
+        filter_row.addWidget(self.img_viewer, stretch=1)
+        filter_row.addWidget(self.gray_filter_editor, stretch=1)
+        filter_row.addWidget(self.small_object_filter_editor, stretch=1)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addLayout(filter_row)
+        layout.addWidget(self.advanced_section)
         self.setLayout(layout)
 
     def get_filter_results(self) -> FilterResults:
@@ -389,9 +508,11 @@ class MultiChannelFilterEditor(QtWidgets.QWidget):
         gray_value = self.gray_filter_editor.slider.get_value()
         small_obj_value = self.small_object_filter_editor.spin_box.get_value()
         small_obj_img = self.editor_state.get_small_objects_img()
+        erosion_radius = self.erosion_spin_box.get_value()
         return FilterResults(
             file_path=self.file_path,
             gray_filter_value=gray_value,
             min_size=small_obj_value,
             small_object_filtered_img=small_obj_img,
+            erosion_radius=erosion_radius,
         )

--- a/pycroglia/ui/widgets/imagefilters/results.py
+++ b/pycroglia/ui/widgets/imagefilters/results.py
@@ -10,6 +10,7 @@ class FilterResults:
         gray_filter_value: float,
         min_size: int,
         small_object_filtered_img: NDArray,
+        erosion_radius: int = 3,
     ):
         """
         Args:
@@ -17,11 +18,13 @@ class FilterResults:
             gray_filter_value (float): Value used for the gray filter.
             min_size (int): Minimum size for small object removal.
             small_object_filtered_img (np.ndarray): Image after small object removal.
+            erosion_radius (int): Radius for the diamond erosion footprint. Default is 3.
         """
         self.file_path = file_path
         self.gray_filter_value = gray_filter_value
         self.min_size = min_size
         self.small_object_filtered_img = small_object_filtered_img
+        self.erosion_radius = erosion_radius
 
     def as_dict(self) -> dict:
         """Returns the filter results as a dictionary.
@@ -34,4 +37,5 @@ class FilterResults:
             "gray_filter_value": self.gray_filter_value,
             "min_size": self.min_size,
             "small_object_filtered_img": self.small_object_filtered_img,
+            "erosion_radius": self.erosion_radius,
         }

--- a/pycroglia/ui/widgets/segmentation/editor.py
+++ b/pycroglia/ui/widgets/segmentation/editor.py
@@ -3,6 +3,8 @@ from typing import Optional
 from PyQt6 import QtWidgets
 from numpy.typing import NDArray
 
+from pycroglia.core.errors.errors import PycrogliaException
+
 from pycroglia.core.labeled_cells import LabelingStrategy, LabeledCells
 from pycroglia.ui.controllers.segmentation_state import SegmentationEditorState
 from pycroglia.ui.widgets.cells.cells_panel import CellsPanel
@@ -97,6 +99,7 @@ class SegmentationEditor(QtWidgets.QWidget):
         img: NDArray,
         labeling_strategy: LabelingStrategy,
         min_size: int,
+        erosion_radius: int = 3,
         with_progress_bar: bool = False,
         headers: Optional[list[str]] = None,
         rollback_button_text: Optional[str] = None,
@@ -111,6 +114,7 @@ class SegmentationEditor(QtWidgets.QWidget):
             img (NDArray): 3D binary image to segment.
             labeling_strategy (LabelingStrategy): Strategy for labeling connected components.
             min_size (int): Minimum size for objects to keep after noise removal.
+            erosion_radius (int): Radius for the diamond erosion footprint. Default is 3.
             with_progress_bar (bool, optional): Whether to show a progress bar during segmentation.
             headers (Optional[list[str]], optional): Column headers for the cell list.
             rollback_button_text (Optional[str], optional): Text for the rollback button.
@@ -135,7 +139,7 @@ class SegmentationEditor(QtWidgets.QWidget):
         )
 
         # Properties
-        self.state = SegmentationEditorState(img, labeling_strategy, min_size)
+        self.state = SegmentationEditorState(img, labeling_strategy, min_size, erosion_radius)
         self.with_progress_bar = with_progress_bar
 
         # Widgets
@@ -210,6 +214,18 @@ class SegmentationEditor(QtWidgets.QWidget):
             self.state.segment_cell(
                 selected_cell_info[0], selected_cell_info[1], progress_bar
             )
+        except PycrogliaException as e:
+            if e.error_code == 2001:
+                if progress_bar:
+                    progress_bar.close()
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Segmentation Error",
+                    "The program finds 0 nuclei to segment your object into. "
+                    "Adjust Erosion in the previous window to a lower number.",
+                )
+                return
+            raise
         finally:
             if progress_bar:
                 progress_bar.close()

--- a/pycroglia/ui/widgets/segmentation/stacks.py
+++ b/pycroglia/ui/widgets/segmentation/stacks.py
@@ -79,6 +79,7 @@ class SegmentationEditorStack(QtWidgets.QWidget):
                 img=elem.small_object_filtered_img,
                 labeling_strategy=SkimageImgLabeling(SkimageCellConnectivity.CORNERS),
                 min_size=elem.min_size,
+                erosion_radius=elem.erosion_radius,
                 with_progress_bar=True,
                 headers=self.headers_text,
                 rollback_button_text=self.rollback_button_text,

--- a/pycroglia/ui/widgets/segmentation/tests/test_stacks.py
+++ b/pycroglia/ui/widgets/segmentation/tests/test_stacks.py
@@ -61,11 +61,13 @@ def test_segmentation_editor_stack_add_tabs_creates_editors(
     mock_result1.small_object_filtered_img = Mock()
     mock_result1.min_size = 100
     mock_result1.file_path = "/path/to/file1.tif"
+    mock_result1.erosion_radius = 3
 
     mock_result2 = Mock(spec=FilterResults)
     mock_result2.small_object_filtered_img = Mock()
     mock_result2.min_size = 150
     mock_result2.file_path = "/path/to/file2.tif"
+    mock_result2.erosion_radius = 3
 
     results = [mock_result1, mock_result2]
 
@@ -86,6 +88,7 @@ def test_segmentation_editor_stack_add_tabs_creates_editors(
         img=mock_result1.small_object_filtered_img,
         labeling_strategy=mock_labeling_strategy,
         min_size=mock_result1.min_size,
+        erosion_radius=mock_result1.erosion_radius,
         with_progress_bar=True,
         headers=["Cell Number", "Cell Size"],
         rollback_button_text="Rollback",
@@ -115,6 +118,7 @@ def test_segmentation_editor_stack_add_tabs_clears_existing_tabs(
         mock_result.small_object_filtered_img = Mock()
         mock_result.min_size = 100
         mock_result.file_path = "/path/to/file.tif"
+        mock_result.erosion_radius = 3
 
         segmentation_editor_stack.add_tabs([mock_result])
 
@@ -134,6 +138,7 @@ def test_segmentation_editor_stack_add_tabs_sets_correct_tab_names(
     mock_result.small_object_filtered_img = Mock()
     mock_result.min_size = 100
     mock_result.file_path = "/path/to/test_file.tif"
+    mock_result.erosion_radius = 3
 
     mock_path = Mock()
     mock_path.name = "test_file.tif"


### PR DESCRIPTION
Changes:

Erosion UI Added: It adds an erosion_radius input (via a spin box) to the MultiChannelFilterEditor, passing this value through to the FilterResults and SegmentationEditorStack.

Segmentation Error Handling: It adds a specific try-except block to catch a PycrogliaException with error code 2001 (which happens when 0 nuclei are found) inside SegmentationEditor. When this occurs, it displays a user-friendly UI warning dialog (QMessageBox) advising the user to "Adjust Erosion in the previous window to a lower number."